### PR TITLE
Implementação do recaptcha sem o extra.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "chart.js": "^3.6.0",
         "date-fns": "^2.28.0",
         "ng2-charts": "^3.0.11",
+        "ngx-captcha": "^11.0.0",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
@@ -8928,6 +8929,18 @@
         "@angular/core": ">=11.0.0",
         "chart.js": "^3.4.0",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/ngx-captcha": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-captcha/-/ngx-captcha-11.0.0.tgz",
+      "integrity": "sha512-C98h1ZtmiTz6LYF8xEd4A8jeT1oQO+l5evWaldFVMU3Fh2YsDDP+5F6g8itN0VA/Ep8rxkSk2MJePa1eWwJxHQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^13.0.0",
+        "@angular/core": "^13.0.0"
       }
     },
     "node_modules/nice-napi": {
@@ -19404,6 +19417,14 @@
       "integrity": "sha512-HHy188JIGt48tbww8MhT9PYGcFNCMeQCzVbQoezmunKxQcjg3dBatLov+qoLXbSQvhRYbYVowthTtY7/7ZsiSg==",
       "requires": {
         "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      }
+    },
+    "ngx-captcha": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-captcha/-/ngx-captcha-11.0.0.tgz",
+      "integrity": "sha512-C98h1ZtmiTz6LYF8xEd4A8jeT1oQO+l5evWaldFVMU3Fh2YsDDP+5F6g8itN0VA/Ep8rxkSk2MJePa1eWwJxHQ==",
+      "requires": {
         "tslib": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chart.js": "^3.6.0",
     "date-fns": "^2.28.0",
     "ng2-charts": "^3.0.11",
+    "ngx-captcha": "^11.0.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { RecuperarSenhaComponent } from './components/recuperar-senha/recuperar-
 import { UsuarioNaoVerificadoComponent } from './components/usuario-nao-verificado/usuario-nao-verificado.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '../shared/material.module';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [
@@ -22,6 +23,7 @@ import { MaterialModule } from '../shared/material.module';
     ReactiveFormsModule,
     MaterialModule,
     FormsModule,
+    SharedModule
   ],
 })
 export class AuthModule {}

--- a/src/app/auth/components/cadastro/cadastro.component.html
+++ b/src/app/auth/components/cadastro/cadastro.component.html
@@ -84,5 +84,6 @@
     >
       Entrar com o google
     </button>
+    <app-recaptcha></app-recaptcha>
   </form>
 </div>

--- a/src/app/auth/components/login/login.component.html
+++ b/src/app/auth/components/login/login.component.html
@@ -22,5 +22,6 @@
         <button (click)="onLoginGoogle()" type="button" mat-raised-button color="warn">
             Entrar com o google
         </button>
+        <app-recaptcha></app-recaptcha>
     </form>
 </div>

--- a/src/app/shared/components/recaptcha/recaptcha.component.html
+++ b/src/app/shared/components/recaptcha/recaptcha.component.html
@@ -1,0 +1,12 @@
+<div>
+    <form [formGroup]="aFormGroup">
+        <ngx-recaptcha2 #captchaElem 
+        [siteKey]="siteKey" 
+        [size]="size" 
+        [hl]="lang"
+        [theme]="theme" 
+        [type]="type" 
+        formControlName="recaptcha">
+        </ngx-recaptcha2>
+    </form>
+</div>

--- a/src/app/shared/components/recaptcha/recaptcha.component.spec.ts
+++ b/src/app/shared/components/recaptcha/recaptcha.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecaptchaComponent } from './recaptcha.component';
+
+describe('RecaptchaComponent', () => {
+  let component: RecaptchaComponent;
+  let fixture: ComponentFixture<RecaptchaComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecaptchaComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecaptchaComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/recaptcha/recaptcha.component.ts
+++ b/src/app/shared/components/recaptcha/recaptcha.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-recaptcha',
+  templateUrl: './recaptcha.component.html',
+  styleUrls: ['./recaptcha.component.scss']
+})
+export class RecaptchaComponent implements OnInit {
+
+  public aFormGroup!: FormGroup
+
+  constructor(private formBuilder: FormBuilder) { }
+
+  public theme: 'light' | 'dark' = 'light';
+  public size: 'compact' | 'normal' = 'normal';
+  public lang = 'pt';
+  public type: 'image' | 'audio' = 'image';
+  public siteKey:string = '6Lexg0ggAAAAABxYoc_oHkpddQ74SqffhRT8NTHo'
+
+  ngOnInit() {
+
+    this.aFormGroup = this.formBuilder.group({
+      recaptcha: ['', Validators.required]
+    });
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -2,14 +2,26 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LoaderComponent } from './components/loader/loader.component';
 import { MaterialModule } from './material.module';
+import { RecaptchaComponent } from './components/recaptcha/recaptcha.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgxCaptchaModule } from 'ngx-captcha';
 
 @NgModule({
   declarations: [
     // recursos que fazem parte do módulo (componentes, pipes, diretivas)
-    LoaderComponent,
+    LoaderComponent, RecaptchaComponent
   ],
-  imports: [CommonModule, MaterialModule],
-  exports: [LoaderComponent],
+  imports: [
+    CommonModule, 
+    MaterialModule,
+    ReactiveFormsModule,
+    FormsModule,
+    NgxCaptchaModule
+  ],
+  exports: [
+    LoaderComponent, 
+    RecaptchaComponent
+  ],
 })
 export class SharedModule {}
 


### PR DESCRIPTION
Adição do reCaptcha sem a funcionalidade extra.

- [x] Criação do componente reCaptcha em app/shared/components.
- [x] instalação do ngx-captcha via npm.
- [x] importações e exportações para o funcionamento da implementação (Observar shared.module.ts e auth.module.ts).
- [x] Adição dos reCaptcha feita via importação em login.html e cadastro.html

A adição da funcionalidade extra será feita no pull request "Recaptcha extra addition" futuramente lançado (Atualmente em trabalho).