### PR TITLE
Adição dos termos de privacidade

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,7 +19,7 @@ import { DashboardModule } from './dashboard/dashboard.module';
 import { ServiceWorkerModule } from '@angular/service-worker';
 
 @NgModule({
-  declarations: [AppComponent ],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/src/app/auth/components/cadastro/cadastro.component.html
+++ b/src/app/auth/components/cadastro/cadastro.component.html
@@ -3,7 +3,7 @@
   <p>Seja bem-vindo(a) de volta!</p>
   <mat-stepper orientation="vertical" #stepper>
     <form [formGroup]="signupForm" (ngSubmit)="onSubmit()">
-      
+
       <mat-step [stepControl]="signupForm">
         <ng-template matStepLabel>Nome</ng-template>
         <mat-form-field appearance="fill">
@@ -15,105 +15,115 @@
         <div>
           <button mat-button matStepperNext>Proximo</button>
         </div>
-        </mat-step>
+      </mat-step>
 
-        <mat-step [stepControl]="signupForm">
-          <ng-template matStepLabel>Seu Endereço</ng-template>
-          <mat-form-field appearance="fill">
-            <mat-label>Endereço</mat-label>
-            <input matInput formControlName="nick" placeholder="Ex. 1 Main St, New York, NY" required>
-          </mat-form-field>
+      <mat-step [stepControl]="signupForm">
+        <ng-template matStepLabel>Seu Endereço</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Endereço</mat-label>
+          <input matInput formControlName="nick" placeholder="Ex. 1 Main St, New York, NY" required>
+        </mat-form-field>
 
-          <div>
-            <button mat-button matStepperPrevious>Voltar</button>
-            <button mat-button matStepperNext>Proximo</button>
-          </div>
-        </mat-step>
+        <div>
+          <button mat-button matStepperPrevious>Voltar</button>
+          <button mat-button matStepperNext>Proximo</button>
+        </div>
+      </mat-step>
 
-        <mat-step [stepControl]="signupForm">
-          <ng-template matStepLabel>Seu Titulo</ng-template>
-          <mat-form-field appearance="fill">
-            <mat-label>Seu título</mat-label>
-            <input matInput placeholder="Ex: Apreciador de cuscuz" formControlName="nick" required />
-            <mat-error *ngIf="signupForm.get('nick')?.errors?.['required']">Campo obrigatório</mat-error>
-            <mat-icon matPrefix>person</mat-icon>
-          </mat-form-field>
-          <div>
-            <button mat-button matStepperPrevious>Voltar</button>
-            <button mat-button matStepperNext>Proximo</button>
-          </div>
-        </mat-step>
+      <mat-step [stepControl]="signupForm">
+        <ng-template matStepLabel>Seu Titulo</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Seu título</mat-label>
+          <input matInput placeholder="Ex: Apreciador de cuscuz" formControlName="nick" required />
+          <mat-error *ngIf="signupForm.get('nick')?.errors?.['required']">Campo obrigatório</mat-error>
+          <mat-icon matPrefix>person</mat-icon>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperPrevious>Voltar</button>
+          <button mat-button matStepperNext>Proximo</button>
+        </div>
+      </mat-step>
 
-        <mat-step [stepControl]="signupForm">
-          <ng-template matStepLabel> Email</ng-template>
-          <mat-form-field appearance="fill">
-            <mat-label>Email</mat-label>
-            <input matInput placeholder="Seu email" formControlName="email" required />
-            <mat-error *ngIf="signupForm.get('email')?.errors?.['required']">Campo obrigatório</mat-error>
-            <mat-error *ngIf="signupForm.get('email')?.errors?.['email']">Email inválido</mat-error>
-            <mat-icon matPrefix>email</mat-icon>
-          </mat-form-field>
-          <div>
-            <button mat-button matStepperPrevious>Voltar</button>
-            <button mat-button matStepperNext>Proximo</button>
-          </div>
-        </mat-step>
+      <mat-step [stepControl]="signupForm">
+        <ng-template matStepLabel> Email</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Email</mat-label>
+          <input matInput placeholder="Seu email" formControlName="email" required />
+          <mat-error *ngIf="signupForm.get('email')?.errors?.['required']">Campo obrigatório</mat-error>
+          <mat-error *ngIf="signupForm.get('email')?.errors?.['email']">Email inválido</mat-error>
+          <mat-icon matPrefix>email</mat-icon>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperPrevious>Voltar</button>
+          <button mat-button matStepperNext>Proximo</button>
+        </div>
+      </mat-step>
 
-        <mat-step [stepControl]="signupForm">
-          <ng-template matStepLabel> Senha</ng-template>
-          <mat-form-field appearance="fill">
-            <mat-label>Senha</mat-label>
-      <input matInput placeholder="Sua senha" formControlName="senha" [type]="hide ? 'password' : 'text'" required />
-      <a mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'"
-        [attr.aria-pressed]="hide">
-        <mat-icon>{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
-      </a>
+      <mat-step [stepControl]="signupForm">
+        <ng-template matStepLabel> Senha</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Senha</mat-label>
+          <input matInput placeholder="Sua senha" formControlName="senha" [type]="hide ? 'password' : 'text'" required />
+          <a mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'"
+            [attr.aria-pressed]="hide">
+            <mat-icon>{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
+          </a>
 
-      <mat-error *ngIf="signupForm.get('senha')?.errors?.['required']">Campo obrigatório</mat-error>
-      <mat-error *ngIf="signupForm.get('senha')?.errors?.['minlength']">O mínimo são 8 caracteres
-      </mat-error>
-      <mat-icon matPrefix>key</mat-icon>
-          </mat-form-field>
-          <div>
-            <button mat-button matStepperPrevious>Voltar</button>
-            <button mat-button matStepperNext>Proximo</button>
-          </div>
-        </mat-step>
+          <mat-error *ngIf="signupForm.get('senha')?.errors?.['required']">Campo obrigatório</mat-error>
+          <mat-error *ngIf="signupForm.get('senha')?.errors?.['minlength']">O mínimo são 8 caracteres
+          </mat-error>
+          <mat-icon matPrefix>key</mat-icon>
+        </mat-form-field>
+        <div>
+          <button mat-button matStepperPrevious>Voltar</button>
+          <button mat-button matStepperNext>Proximo</button>
+        </div>
+      </mat-step>
 
-        <mat-step [stepControl]="signupForm">
-          <ng-template matStepLabel> Confirme a sua Senha</ng-template>
-          <mat-form-field appearance="fill">
-            <mat-label>Confirmar senha</mat-label>
-            <input matInput placeholder="Confirmar senha" formControlName="confirma_senha" type="password" />
-            <mat-icon matPrefix>key</mat-icon>
-          </mat-form-field>
-          <span class="mat-error"
-            *ngIf="signupForm.errors?.['matchPasswords'] && signupForm.get('confirma_senha')?.touched">
-            As senhas não correspondem
-          </span>
-          <div>
-            <button mat-button matStepperPrevious>Voltar</button>
-            <button mat-button matStepperNext>Proximo</button>
-          </div>
-        </mat-step>
+      <mat-step [stepControl]="signupForm">
+        <ng-template matStepLabel> Confirme a sua Senha</ng-template>
+        <mat-form-field appearance="fill">
+          <mat-label>Confirmar senha</mat-label>
+          <input matInput placeholder="Confirmar senha" formControlName="confirma_senha" type="password" />
+          <mat-icon matPrefix>key</mat-icon>
+        </mat-form-field>
+        <span class="mat-error"
+          *ngIf="signupForm.errors?.['matchPasswords'] && signupForm.get('confirma_senha')?.touched">
+          As senhas não correspondem
+        </span>
+        <div>
+          <button mat-button matStepperPrevious>Voltar</button>
+          <button mat-button matStepperNext>Proximo</button>
+        </div>
+      </mat-step>
 
-        <mat-step>
-          <ng-template matStepLabel>Done</ng-template>
+      <mat-step>
+        <ng-template matStepLabel>Termos de Privacidade</ng-template>
 
-          <button mat-raised-button color="primary" (click)="onSubmit()" [disabled]="signupForm.invalid">
-            Cadastrar
-          </button>
+        <button mat-stroked-button color="primary" (click)="onClickDialogTermosDePrivacidade()"><strong>Termos de uso</strong></button> <br>
+        <mat-checkbox formControlName="checkbox">Concordo com os Termos de Privacidade. </mat-checkbox>
 
-          <span>ou</span>
+        <div>
+          <button mat-button matStepperPrevious>Voltar</button>
+          <button mat-button matStepperNext>Proximo</button>
+        </div>
+      </mat-step>
 
-          <button (click)="onLoginGoogle()" type="button" mat-raised-button color="warn">
-            Entrar com o google
-          </button>
+      <mat-step>
+        <ng-template matStepLabel>Done</ng-template>
 
-        </mat-step>
-    
+        <button mat-raised-button color="primary" (click)="onSubmit()" [disabled]="signupForm.invalid">
+          Cadastrar
+        </button>
 
+        <span>ou</span>
+
+        <button (click)="onLoginGoogle()" type="button" mat-raised-button color="warn">
+          Entrar com o google
+        </button>
+
+      </mat-step>
     </form>
 
   </mat-stepper>
-  </div>
+</div>

--- a/src/app/auth/components/cadastro/cadastro.component.ts
+++ b/src/app/auth/components/cadastro/cadastro.component.ts
@@ -1,12 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 import {
   AbstractControl,
+  CheckboxRequiredValidator,
   FormBuilder,
   ValidationErrors,
   Validators,
 } from '@angular/forms';
 import { HotToastService } from '@ngneat/hot-toast';
 import { AuthService } from 'src/app/core/services/auth/auth.service';
+import { TermosDePrivacidadeComponent } from 'src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component';
+import { MatDialog } from '@angular/material/dialog';
+
 
 @Component({
   selector: 'app-cadastro',
@@ -22,6 +26,7 @@ export class CadastroComponent implements OnInit {
       email: ['', [Validators.required, Validators.email]],
       senha: ['', [Validators.required, Validators.minLength(8)]],
       confirma_senha: [''],
+      checkbox: [false, [Validators.requiredTrue]],
     },
     { validators: [this.matchPasswords] }
   );
@@ -35,7 +40,8 @@ export class CadastroComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
-    private toast: HotToastService
+    private toast: HotToastService,
+    private dialog: MatDialog
   ) {}
 
   onSubmit() {
@@ -65,5 +71,8 @@ export class CadastroComponent implements OnInit {
       .subscribe();
   }
 
+  onClickDialogTermosDePrivacidade() {
+    this.dialog.open(TermosDePrivacidadeComponent);
+  }
   ngOnInit(): void {}
 }

--- a/src/app/auth/components/login-providers/login-providers/login-providers.component.html
+++ b/src/app/auth/components/login-providers/login-providers/login-providers.component.html
@@ -26,12 +26,12 @@
             Entrar com o Facebook
         </button>
     </div>
-   
+
     <div mat-dialog-actions>
         <button  mat-icon-button (click)="closeModal()" type="button" mat-raised-button color="basic">
             <mat-icon > close</mat-icon>
 
         </button>
     </div>
-   
+    
 </div>

--- a/src/app/auth/components/login/login.component.html
+++ b/src/app/auth/components/login/login.component.html
@@ -1,45 +1,41 @@
-
-<div class="container" >
+<div class="container">
     <div class="form-container">
-    <h1 class="titulo"><strong>Login</strong></h1> 
-<h2 class="titulo"><strong>Seja bem-vindo(a) de volta!</strong></h2>
+        <h1 class="titulo"><strong>Login</strong></h1>
+        <h2 class="titulo"><strong>Seja bem-vindo(a) de volta!</strong></h2>
 
-
-    <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" >
-        <mat-form-field appearance="fill" class="inputEmail" >
-            <mat-label>Email</mat-label>
-            <input class="inputEmail" matInput placeholder="Seu email" formControlName="email" required>
-            <mat-error *ngIf="loginForm.get('email')?.errors?.['required']">Campo obrigatório</mat-error>
-            <mat-error *ngIf="loginForm.get('email')?.errors?.['email']">Email inválido</mat-error>
-            <mat-icon matPrefix>person</mat-icon>
-        </mat-form-field>
-        <mat-form-field appearance="fill">
-            <mat-label>Senha</mat-label>
-           
-            
-            <input matInput placeholder="Sua senha" formControlName="senha" [type]="hide ? 'password' : 'text'"
-            required>
-        <a mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'"
-            [attr.aria-pressed]="hide">
-            <mat-icon>{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
-        </a>
-
-            <mat-error *ngIf="loginForm.get('senha')?.errors?.['required']">Campo obrigatório</mat-error>
-            <mat-error *ngIf="loginForm.get('senha')?.errors?.['minlength']">O mínimo são 8 caracteres</mat-error>
-            <mat-icon matPrefix>key</mat-icon>
+        <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
+            <mat-form-field appearance="fill" class="inputEmail">
+                <mat-label>Email</mat-label>
+                <input class="inputEmail" matInput placeholder="Seu email" formControlName="email" required>
+                <mat-error *ngIf="loginForm.get('email')?.errors?.['required']">Campo obrigatório</mat-error>
+                <mat-error *ngIf="loginForm.get('email')?.errors?.['email']">Email inválido</mat-error>
+                <mat-icon matPrefix>person</mat-icon>
             </mat-form-field>
-    <div class="btn-container">
-        <button mat-raised-button color="primary" [disabled]="loginForm.invalid">Login do Usuário</button>
+            <mat-form-field appearance="fill">
+                <mat-label>Senha</mat-label>
+
+                <input matInput placeholder="Sua senha" formControlName="senha" [type]="hide ? 'password' : 'text'"
+                    required>
+                <a mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'"
+                    [attr.aria-pressed]="hide">
+                    <mat-icon>{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
+                </a>
+
+                <mat-error *ngIf="loginForm.get('senha')?.errors?.['required']">Campo obrigatório</mat-error>
+                <mat-error *ngIf="loginForm.get('senha')?.errors?.['minlength']">O mínimo são 8 caracteres</mat-error>
+                <mat-icon matPrefix>key</mat-icon>
+            </mat-form-field>
+            <div class="btn-container">
+                <button mat-raised-button color="primary" [disabled]="loginForm.invalid">Login do Usuário</button>
+
+            </div>
+        </form>
+        <span>ou</span>
+        <a routerLink="/recuperar-senha">Esqueci minha senha</a>
+        <button (click)="onClickDialogProvedores()" type="button" mat-raised-button color="warn">
+            Entrar com provedores
+        </button>
+        <app-recaptcha></app-recaptcha>
 
     </div>
-        </form>
-    <span>ou</span>
-    <a routerLink="/recuperar-senha">Esqueci minha senha</a>
-    <button  (click)="onClickDialog()" type="button" mat-raised-button color ="warn">
-        Entrar com provedores
-    </button>
-    <app-recaptcha></app-recaptcha>
-
-        </div>
 </div>
-

--- a/src/app/auth/components/login/login.component.scss
+++ b/src/app/auth/components/login/login.component.scss
@@ -1,39 +1,37 @@
-.titulo{
-
-   text-align: center;
-   color: blueviolet;
-   
-
-}
-
-.botao{
+.titulo {
+    text-align: center;
     color: blueviolet;
-
 }
-.container{
+
+.botao {
+    color: blueviolet;
+}
+
+.container {
     width: 100vw;
     height: 100%;
     display: flex;
     justify-content: center;
     flex-direction: column;
     align-items: center;
-
 }
-.form-container{
+
+.form-container {
     width: 600px;
     height: auto;
     display: flex;
-    justify-content:center;
+    justify-content: center;
     flex-direction: column;
-    align-items:center;
+    align-items: center;
 }
-.btn-container{
+
+.btn-container {
     display: flex;
     justify-content: center;
     width: 100%;
 }
 
-.inputEmail{
+.inputEmail {
     width: 260px;
     padding-right: 30px;
 }

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -21,7 +21,7 @@ export class LoginComponent implements OnInit {
     private fb: FormBuilder,
     private authService: AuthService,
     private toast: HotToastService,
-    private dialog : MatDialog,
+    private dialog: MatDialog,
   ) {}
 
   onSubmit() {
@@ -39,9 +39,9 @@ export class LoginComponent implements OnInit {
   }
 
 
-  onClickDialog(){
-         this.dialog.open(LoginProvidersComponent);
-    }
-  
+  onClickDialogProvedores() {
+    this.dialog.open(LoginProvidersComponent);
+  }
+
   ngOnInit(): void { }
 }

--- a/src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component.html
+++ b/src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component.html
@@ -1,0 +1,43 @@
+<h1>Política Privacidade</h1>
+<p>A sua privacidade é importante para nós. É política do Diarios respeitar a sua privacidade em relação a qualquer
+    informação sua que possamos coletar no site Diarios, e outros sites que possuímos e operamos.
+</p>
+<p>Solicitamos informações pessoais apenas quando realmente precisamos delas para lhe fornecer um serviço. Fazemo-lo por
+    meios justos e legais, com o seu conhecimento e consentimento. Também informamos por que estamos coletando e como
+    será usado.
+</p>
+<p>Apenas retemos as informações coletadas pelo tempo necessário para fornecer o serviço solicitado. Quando armazenamos
+    dados, protegemos dentro de meios comercialmente aceitáveis ​​para evitar perdas e roubos, bem como acesso,
+    divulgação, cópia, uso ou modificação não autorizados.
+</p>
+<p>Não compartilhamos informações de identificação pessoal publicamente ou com terceiros, exceto quando exigido por lei.
+</p>
+<p>O nosso site pode ter links para sites externos que não são operados por nós. Esteja ciente de que não temos controle
+    sobre o conteúdo e práticas desses sites e não podemos aceitar responsabilidade por suas respectivas políticas de
+    privacidade.
+</p>
+<p>Você é livre para recusar a nossa solicitação de informações pessoais, entendendo que talvez não possamos fornecer
+    alguns dos serviços desejados.
+</p>
+<p>O uso continuado de nosso site será considerado como aceitação de nossas práticas em torno de Aviso de Privacidad e
+    informações pessoais. Se você tiver alguma dúvida sobre como lidamos com dados do usuário e informações pessoais,
+    entre em contacto connosco.
+</p>
+<h2>Compromisso do Usuário
+</h2>
+<p>O usuário se compromete a fazer uso adequado dos conteúdos e da informação que o Diarios oferece no site e com
+    caráter enunciativo, mas não limitativo:
+</p>
+
+<ul>
+    <li>A) Não se envolver em atividades que sejam ilegais ou contrárias à boa fé a à ordem pública;
+    </li>
+    <li>B) Não difundir propaganda ou conteúdo de natureza racista, xenofóbica, de apologia ao terrorismo ou contra os direitos humanos;
+    </li>
+    <li>C) Não causar danos aos sistemas físicos (hardwares) e lógicos (softwares) do Diarios, de seus fornecedores ou
+        terceiros, para introduzir ou disseminar vírus informáticos ou quaisquer outros sistemas de hardware ou software
+        que sejam capazes de causar danos anteriormente mencionados.
+    </li>
+</ul>
+
+<p>Esta política é efetiva a partir de <strong>Junho/2022</strong>.</p>

--- a/src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component.spec.ts
+++ b/src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TermosDePrivacidadeComponent } from './termos-de-privacidade.component';
+
+describe('TermosDePrivacidadeComponent', () => {
+  let component: TermosDePrivacidadeComponent;
+  let fixture: ComponentFixture<TermosDePrivacidadeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TermosDePrivacidadeComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TermosDePrivacidadeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component.ts
+++ b/src/app/shared/components/termos-de-privacidade/termos-de-privacidade.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-termos-de-privacidade',
+  templateUrl: './termos-de-privacidade.component.html',
+  styleUrls: ['./termos-de-privacidade.component.scss']
+})
+export class TermosDePrivacidadeComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -5,11 +5,12 @@ import { MaterialModule } from './material.module';
 import { RecaptchaComponent } from './components/recaptcha/recaptcha.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgxCaptchaModule } from 'ngx-captcha';
+import { TermosDePrivacidadeComponent } from './components/termos-de-privacidade/termos-de-privacidade.component';
 
 @NgModule({
   declarations: [
     // recursos que fazem parte do módulo (componentes, pipes, diretivas)
-    LoaderComponent, RecaptchaComponent
+    LoaderComponent, RecaptchaComponent, TermosDePrivacidadeComponent
   ],
   imports: [
     CommonModule, 
@@ -20,7 +21,8 @@ import { NgxCaptchaModule } from 'ngx-captcha';
   ],
   exports: [
     LoaderComponent, 
-    RecaptchaComponent
+    RecaptchaComponent,
+    TermosDePrivacidadeComponent
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
Adição dos termos de privacidade.

- [ ] Criação do componente "termos-de-privacidade" em src/app/shared/components.
- [ ] importações e exportações criadas nos módulos de app/shared e app/auth.
- [ ] Criação de um novo mat-step no HTML  de cadastro para adição dos termos de privacidade.
- [ ] Modificação no TS Reactiveforms "signupFor" de cadastro  para que o checkbox de termos de uso seja um requisito.
- [ ] Pequena limpeza de código removendo barras de espaços extras.